### PR TITLE
Do database operation outside lock block

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,12 +7,16 @@ trigger:
 - master
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'Ubuntu-18.04'
 
 variables:
   buildConfiguration: 'Release'
 
 steps:
+- task: UseDotNet@2
+  inputs:
+    version: 3.1.x
+
 - script: dotnet build ./src/Kirari/Kirari.csproj /p:Version=0.0.$(Build.BuildId) --configuration $(buildConfiguration) -o $(Build.ArtifactStagingDirectory)
   displayName: 'dotnet build $(buildConfiguration)'
 

--- a/src/Kirari.Runner/Program.cs
+++ b/src/Kirari.Runner/Program.cs
@@ -5,10 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
-using Kirari.Diagnostics;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.Memory;
-using MySql.Data.MySqlClient;
 
 namespace Kirari.Runner
 {
@@ -27,7 +24,7 @@ namespace Kirari.Runner
 
             var connectionString = config.GetConnectionString("Default");
 
-            Console.WriteLine($"Setup");
+            Console.WriteLine("Setup");
             const string databaseName = "KirariTest";
             using (var conn = new SampleConnection(connectionString, false))
             {
@@ -175,7 +172,7 @@ CREATE TABLE TestData
             }
             finally
             {
-                Console.WriteLine($"Cleanup");
+                Console.WriteLine("Cleanup");
                 using (var conn = new SampleConnection(connectionString, false))
                 {
                     await conn.ExecuteAsync($"DROP DATABASE {databaseName};");

--- a/src/Kirari/ConnectionStrategies/QueuedSingleConnectionStrategy.cs
+++ b/src/Kirari/ConnectionStrategies/QueuedSingleConnectionStrategy.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -104,18 +104,16 @@ namespace Kirari.ConnectionStrategies
             this._transaction = connection.Connection.BeginTransaction(isolationLevel);
         }
 
-#pragma warning disable 1998
-        public async Task CommitAsync(CancellationToken cancellationToken)
-#pragma warning restore 1998
+        public Task CommitAsync(CancellationToken cancellationToken)
         {
             this._transaction?.Commit();
+            return Task.CompletedTask;
         }
 
-#pragma warning disable 1998
-        public async Task RollbackAsync(CancellationToken cancellationToken)
+        public Task RollbackAsync(CancellationToken cancellationToken)
         {
-#pragma warning restore 1998
             this._transaction?.Rollback();
+            return Task.CompletedTask;
         }
 
         public void EndTransaction()

--- a/src/Kirari/ConnectionStrategies/TermBasedReuseStrategy.cs
+++ b/src/Kirari/ConnectionStrategies/TermBasedReuseStrategy.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
@@ -66,11 +66,10 @@ namespace Kirari.ConnectionStrategies
             return command;
         }
 
-#pragma warning disable 1998
-        public async Task ChangeDatabaseAsync(string databaseName, CancellationToken cancellationToken)
-#pragma warning restore 1998
+        public Task ChangeDatabaseAsync(string databaseName, CancellationToken cancellationToken)
         {
             this._overriddenDatabaseName = databaseName;
+            return Task.CompletedTask;
         }
 
         public DbConnection GetConnectionOrNull(DbCommandProxy command)

--- a/src/Kirari/DbConnectionProxy.cs
+++ b/src/Kirari/DbConnectionProxy.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Data.Common;
 using System.Threading;
@@ -161,11 +161,10 @@ namespace Kirari
         public override void Open()
             => this.OpenAsync(CancellationToken.None).GetAwaiter().GetResult();
 
-#pragma warning disable 1998
-        public override async Task OpenAsync(CancellationToken cancellationToken)
-#pragma warning restore 1998
+        public override Task OpenAsync(CancellationToken cancellationToken)
         {
             //do nothing.
+            return Task.CompletedTask;
         }
 
         public override DataTable GetSchema()


### PR DESCRIPTION
`ChangeDatabase` and `Dispose` may communicate with a server.  In `TermBasedReuseStrategy`, these operations should do outside of the lock of the collection of connections.